### PR TITLE
fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,12 @@ language: go
 notifications:
   email: false
 
-matrix:
-  env:
+env:
+  global:
     - GO111MODULE=on
-  env:
     - GO111MODULE=off
-    global:
-      - secure: "I5aI/oS2frPKuAWiHwNbcnYzIfJm2nQ9qDlabeurkB8FrN643Yetf5p3Az3QbbPhPO7ntIFAoxQBqov4jGv/dAFbygii+WiTQ6n7E1/bCg5rPDMUxo+TWJdqfNmNBdnYt5xE/3C4PpuDqqKKwXkUlc3i/xGHBvGNCD248mbooZw="
-      - PATH=$HOME/gopath/bin:$PATH
+    - secure: "I5aI/oS2frPKuAWiHwNbcnYzIfJm2nQ9qDlabeurkB8FrN643Yetf5p3Az3QbbPhPO7ntIFAoxQBqov4jGv/dAFbygii+WiTQ6n7E1/bCg5rPDMUxo+TWJdqfNmNBdnYt5xE/3C4PpuDqqKKwXkUlc3i/xGHBvGNCD248mbooZw="
+    - PATH=$HOME/gopath/bin:$PATH
 
 install:
   - go get ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ notifications:
 
 env:
   global:
-    - GO111MODULE=on
-    - GO111MODULE=off
     - secure: "I5aI/oS2frPKuAWiHwNbcnYzIfJm2nQ9qDlabeurkB8FrN643Yetf5p3Az3QbbPhPO7ntIFAoxQBqov4jGv/dAFbygii+WiTQ6n7E1/bCg5rPDMUxo+TWJdqfNmNBdnYt5xE/3C4PpuDqqKKwXkUlc3i/xGHBvGNCD248mbooZw="
     - PATH=$HOME/gopath/bin:$PATH
+  matrix:
+    - GO111MODULE=on
+    - GO111MODULE=off
 
 install:
   - go get ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,14 @@ language: go
 notifications:
   email: false
 
-env:
-  global:
-    - secure: "I5aI/oS2frPKuAWiHwNbcnYzIfJm2nQ9qDlabeurkB8FrN643Yetf5p3Az3QbbPhPO7ntIFAoxQBqov4jGv/dAFbygii+WiTQ6n7E1/bCg5rPDMUxo+TWJdqfNmNBdnYt5xE/3C4PpuDqqKKwXkUlc3i/xGHBvGNCD248mbooZw="
-    - PATH=$HOME/gopath/bin:$PATH
+matrix:
+  env:
+    - GO111MODULE=on
+  env:
+    - GO111MODULE=off
+    global:
+      - secure: "I5aI/oS2frPKuAWiHwNbcnYzIfJm2nQ9qDlabeurkB8FrN643Yetf5p3Az3QbbPhPO7ntIFAoxQBqov4jGv/dAFbygii+WiTQ6n7E1/bCg5rPDMUxo+TWJdqfNmNBdnYt5xE/3C4PpuDqqKKwXkUlc3i/xGHBvGNCD248mbooZw="
+      - PATH=$HOME/gopath/bin:$PATH
 
 install:
   - go get ./...

--- a/front-end.md
+++ b/front-end.md
@@ -84,7 +84,7 @@ Supported:
 https://github.com/cojocar/bin2llvm
 
 Supported:
-* ARM
+* ARM -> LLVM IR
 
 ## fcd
 


### PR DESCRIPTION
The fix is based on the suggestions posted by @JuJu227 in #219.

Now the Travis build will run in both Go modules mode and in non-modules mode (i.e. GO111MODULE=on and  GO111MODULE=off).