### PR TITLE
handle nil constants from llvm code (testing with retdec llvm ir

### DIFF
--- a/cmd/ll2go/main.go
+++ b/cmd/ll2go/main.go
@@ -355,14 +355,8 @@ func (d *decompiler) pointerToConst(c constant.Constant) ast.Expr {
 		// handle nil constants 
 		// example error: panic: support for value <nil> not yet implemented
 		if c == nil {
-			
-			// return d.value(c)
-			// return d.constant(constant.Constant(0));
-
-			// make a new integer with value 0 for this
-			return d.value(constant.NewInt(irtypes.I32, 0))
-
-
+			// return d.value(constant.NewInt(irtypes.I32, 0))
+			return ast.NewIdent("nil")
 		}
 		// fmt.Println("Constant: %v", c)
 		panic(fmt.Sprintf("support for value %T not yet implemented", c))

--- a/cmd/ll2go/main.go
+++ b/cmd/ll2go/main.go
@@ -350,7 +350,21 @@ func (d *decompiler) pointerToConst(c constant.Constant) ast.Expr {
 	// Constant expressions
 	case constant.Expression:
 		return d.expr(c)
+
 	default:
+		// handle nil constants 
+		// example error: panic: support for value <nil> not yet implemented
+		if c == nil {
+			
+			// return d.value(c)
+			// return d.constant(constant.Constant(0));
+
+			// make a new integer with value 0 for this
+			return d.value(constant.NewInt(irtypes.I32, 0))
+
+
+		}
+		// fmt.Println("Constant: %v", c)
 		panic(fmt.Sprintf("support for value %T not yet implemented", c))
 	}
 }


### PR DESCRIPTION
fixed this type of errors:
```
ll2go ./if.ll
ll2go: parsing file "./if.ll".
panic: support for value <nil> not yet implemented

goroutine 1 [running]:
main.(*decompiler).pointerToConst(0x40, {0x0, 0x0})
    /home/bob/projects/decomp/cmd/ll2go/main.go:354 +0x5bd
main.(*decompiler).globalDecl(0x636b00, 0xc0001900c0)
    /home/bob/projects/decomp/cmd/ll2go/main.go:307 +0x74
main.ll2go({0x7ffc361d11a3, 0x7}, 0xc000163ea8)
    /home/bob/projects/decomp/cmd/ll2go/main.go:141 +0x547
main.main()
    /home/bob/projects/decomp/cmd/ll2go/main.go:99 +0x2bb


```